### PR TITLE
Remove Git Submodules

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -12,13 +12,10 @@ jobs:
   build:
     name: 🛠️ Build
     runs-on: ubuntu-latest
-    container: natejrex/cmake
+    container: natejrex/cmake-vcpkg
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
-        with:
-          submodules: 'true'
-          token: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Restore Dependency Cache
         id: cache
@@ -61,15 +58,12 @@ jobs:
   common-tests:
     name: 🧪 Common Tests
     runs-on: ubuntu-latest
-    container: natejrex/cmake
+    container: natejrex/cmake-vcpkg
     needs:
       - build
     steps:
       - name: checkout
         uses: actions/checkout@v4
-        with:
-          submodules: 'true'
-          token: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Download Artifact -> build
         uses: actions/download-artifact@v4
@@ -85,15 +79,12 @@ jobs:
   graphics-tests:
     name: 🧪 Graphics Tests
     runs-on: ubuntu-latest
-    container: natejrex/cmake
+    container: natejrex/cmake-vcpkg
     needs:
       - build
     steps:
       - name: checkout
         uses: actions/checkout@v4
-        with:
-          submodules: 'true'
-          token: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Download Artifact -> build
         uses: actions/download-artifact@v4
@@ -111,15 +102,12 @@ jobs:
   math-tests:
     name: 🧪 Math Tests
     runs-on: ubuntu-latest
-    container: natejrex/cmake
+    container: natejrex/cmake-vcpkg
     needs:
       - build
     steps:
       - name: checkout
         uses: actions/checkout@v4
-        with:
-          submodules: 'true'
-          token: ${{ secrets.ACCESS_TOKEN }}
 
       - name: Download Artifact -> build
         uses: actions/download-artifact@v4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vcpkg"]
-	path = vcpkg
-	url = https://github.com/microsoft/vcpkg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,16 @@
 cmake_minimum_required(VERSION 3.27.1)
 
-set(CMAKE_TOOLCHAIN_FILE ${CMAKE_CURRENT_SOURCE_DIR}/vcpkg/scripts/buildsystems/vcpkg.cmake)
+if(NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+    if(DEFINED ENV{VCPKG_ROOT})
+        set(CMAKE_TOOLCHAIN_FILE "$ENV{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake"
+            CACHE FILEPATH "vcpkg toolchain file")
+    else()
+        message(FATAL_ERROR
+            "VCPKG_ROOT is not set. Install vcpkg globally and set VCPKG_ROOT to its installation directory, "
+            "or configure CMake with -DCMAKE_TOOLCHAIN_FILE=<vcpkg-root>/scripts/buildsystems/vcpkg.cmake.")
+    endif()
+endif()
+
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)

--- a/development.md
+++ b/development.md
@@ -12,11 +12,7 @@ This document contains instructions on how to build TitanForge on your machine.
 
 - Download [CMake](https://cmake.org/) (version 3.27.1 or above).
 
-- Clone this repository and it's submodules:
-
-    ```
-    git clone --recurse-submodules https://github.com/NateRex/titanforge.git
-    ```
+- Install [vcpkg](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-powershell#1---set-up-vcpkg) globally and set the `VCPKG_ROOT` environment variable to its installation directory. Ensure the vcpkg executable is also available on your `PATH`.
 
 <br>
 


### PR DESCRIPTION
Slight refactor to remove Git submodule of vcpkg in favor of a global installation managed by the developer on their machine